### PR TITLE
Allow to configure API URL

### DIFF
--- a/src/lib/authentication.js
+++ b/src/lib/authentication.js
@@ -1,3 +1,4 @@
+import TiAuth from '../ti-auth';
 import location from './location';
 
 let AUTH_TOKEN;
@@ -19,6 +20,6 @@ export default {
   },
   unauthorize() {
     AUTH_TOKEN = undefined;
-    location.redirect('http://travel-intelligence.dev/authorize');
+    location.redirect(TiAuth.DASHBOARD_URL + '/authorize');
   }
 };

--- a/src/ti-auth.js
+++ b/src/ti-auth.js
@@ -2,13 +2,13 @@ import Auth from './lib/authentication';
 import API from './lib/api';
 
 export default {
-  initialize(resolve) {
+  initialize(api_url, resolve) {
     if (!Auth.authorize()) {
       Auth.unauthorize();
       return;
     }
     let token = Auth.token();
-    API.get('/api/v1/users/me',
+    API.get(api_url + '/api/v1/users/me',
       resolve.bind(this, token),
       Auth.unauthorize
     );

--- a/src/ti-auth.js
+++ b/src/ti-auth.js
@@ -1,6 +1,14 @@
 import Auth from './lib/authentication';
 import API from './lib/api';
 
+function retrieve_user(resolve) {
+  let token = Auth.token();
+  API.get(this.API_URL + '/api/v1/users/me',
+    resolve.bind(this, token),
+    Auth.unauthorize
+  );
+}
+
 export default {
   API_URL: '',
   DASHBOARD_URL: '',
@@ -9,11 +17,7 @@ export default {
       Auth.unauthorize();
       return;
     }
-    let token = Auth.token();
-    API.get(this.API_URL + '/api/v1/users/me',
-      resolve.bind(this, token),
-      Auth.unauthorize
-    );
+    retrieve_user.call(this, resolve);
   },
   signout() {
     Auth.unauthorize();

--- a/src/ti-auth.js
+++ b/src/ti-auth.js
@@ -3,13 +3,13 @@ import API from './lib/api';
 
 function retrieve_user(resolve) {
   let token = Auth.token();
-  API.get(this.API_URL + '/api/v1/users/me',
-    resolve.bind(this, token),
+  API.get(TiAuth.API_URL + '/api/v1/users/me',
+    resolve.bind(null, token),
     Auth.unauthorize
   );
 }
 
-export default {
+const TiAuth = {
   API_URL: '',
   DASHBOARD_URL: '',
   initialize(resolve) {
@@ -17,9 +17,11 @@ export default {
       Auth.unauthorize();
       return;
     }
-    retrieve_user.call(this, resolve);
+    retrieve_user(resolve);
   },
   signout() {
     Auth.unauthorize();
   }
 };
+
+export default TiAuth;

--- a/src/ti-auth.js
+++ b/src/ti-auth.js
@@ -2,13 +2,13 @@ import Auth from './lib/authentication';
 import API from './lib/api';
 
 export default {
-  initialize(api_url, resolve) {
+  initialize(resolve) {
     if (!Auth.authorize()) {
       Auth.unauthorize();
       return;
     }
     let token = Auth.token();
-    API.get(api_url + '/api/v1/users/me',
+    API.get('/api/v1/users/me',
       resolve.bind(this, token),
       Auth.unauthorize
     );

--- a/src/ti-auth.js
+++ b/src/ti-auth.js
@@ -9,10 +9,21 @@ function retrieve_user(resolve) {
   );
 }
 
+function validate_config() {
+  if (TiAuth.API_URL === '') {
+    throw new Error('`TiAuth.API_URL` needs to be configured.');
+  }
+  if (TiAuth.DASHBOARD_URL === '') {
+    throw new Error('`TiAuth.DASHBOARD_URL` needs to be configured.');
+  }
+}
+
 const TiAuth = {
   API_URL: '',
   DASHBOARD_URL: '',
+
   initialize(resolve) {
+    validate_config();
     if (!Auth.authorize()) {
       Auth.unauthorize();
       return;

--- a/src/ti-auth.js
+++ b/src/ti-auth.js
@@ -2,13 +2,15 @@ import Auth from './lib/authentication';
 import API from './lib/api';
 
 export default {
+  API_URL: '',
+  DASHBOARD_URL: '',
   initialize(resolve) {
     if (!Auth.authorize()) {
       Auth.unauthorize();
       return;
     }
     let token = Auth.token();
-    API.get('/api/v1/users/me',
+    API.get(this.API_URL + '/api/v1/users/me',
       resolve.bind(this, token),
       Auth.unauthorize
     );

--- a/test/lib/authentication_test.js
+++ b/test/lib/authentication_test.js
@@ -5,12 +5,14 @@ import Authentication from '../../src/lib/authentication';
 
 // Internal dependencies to stub
 import location from '../../src/lib/location';
+import TiAuth from '../../src/ti-auth';
 
 describe('Authentication', () => {
   before(function() {
     if (!global.location) {
       global.location = { href: 'http://ti-module.test/' };
     }
+    TiAuth.DASHBOARD_URL = 'https://portal.test';
   });
 
   describe('#authorize', () => {
@@ -48,7 +50,7 @@ describe('Authentication', () => {
 
     it('redirects back to dashboard for remove authentication', test(function() {
       this.mock(location).expects('redirect')
-                         .withExactArgs('http://travel-intelligence.dev/authorize');
+                         .withExactArgs('https://portal.test/authorize');
       Authentication.unauthorize();
     }));
   });

--- a/test/ti-auth_test.js
+++ b/test/ti-auth_test.js
@@ -12,6 +12,7 @@ describe('TiAuth', () => {
     if (!global.location) {
       global.location = { href: 'http://ti-module.test/' };
     }
+    TiAuth.API_URL = 'https://api.test';
   });
 
   describe('#initialize', () => {
@@ -31,7 +32,7 @@ describe('TiAuth', () => {
 
     it('loads user from API', test(function() {
       this.stub(Authentication, 'authorize', () => true);
-      this.mock(API).expects('get').withArgs('/api/v1/users/me');
+      this.mock(API).expects('get').withArgs('https://api.test/api/v1/users/me');
       TiAuth.initialize(function() {});
     }));
 

--- a/test/ti-auth_test.js
+++ b/test/ti-auth_test.js
@@ -8,14 +8,28 @@ import Authentication from '../src/lib/authentication';
 import API from '../src/lib/api';
 
 describe('TiAuth', () => {
-  before(function() {
+  beforeEach(function() {
     if (!global.location) {
       global.location = { href: 'http://ti-module.test/' };
     }
     TiAuth.API_URL = 'https://api.test';
+    TiAuth.DASHBOARD_URL = 'https://api.test';
   });
 
   describe('#initialize', () => {
+   it('throws if API_URL has not been configured', test(function() {
+     TiAuth.API_URL = '';
+     TiAuth.DASHBOARD_URL = 'https://dashboard.test';
+     expect(TiAuth.initialize).to.throw(Error);
+    ;
+   }));
+
+   it('throws if DASHBOARD_URL has not been configured', test(function() {
+     TiAuth.API_URL = 'https://api.test';
+     TiAuth.DASHBOARD_URL = '';
+     expect(TiAuth.initialize).to.throw(Error);
+   }));
+
    it('attempts to authorize the user', test(function() {
      this.stub(Authentication, 'authorize', () => true);
      this.stub(API, 'get');

--- a/test/ti-auth_test.js
+++ b/test/ti-auth_test.js
@@ -61,7 +61,7 @@ describe('TiAuth', () => {
     }));
   });
 
-  describe('#unauthenticate', () => {
+  describe('#signout', () => {
     it('delegates to Authentication#unauthorize', test(function() {
       var stub = spy();
       this.stub(Authentication, 'unauthorize', stub);

--- a/test/ti-auth_test.js
+++ b/test/ti-auth_test.js
@@ -18,21 +18,21 @@ describe('TiAuth', () => {
    it('attempts to authorize the user', test(function() {
      this.stub(Authentication, 'authorize', () => true);
      this.stub(API, 'get');
-     TiAuth.initialize(function() {});
+     TiAuth.initialize('//portal.test', function() {});
    }));
 
     it('unauthorizes if authorization failed', test(function() {
       this.stub(Authentication, 'authorize', false);
       var stub = spy();
       this.stub(Authentication, 'unauthorize', stub);
-      TiAuth.initialize(function() {});
+      TiAuth.initialize('//portal.test', function() {});
       assert.calledOnce(stub);
     }));
 
     it('loads user from API', test(function() {
       this.stub(Authentication, 'authorize', () => true);
-      this.mock(API).expects('get').withArgs('/api/v1/users/me');
-      TiAuth.initialize(function() {});
+      this.mock(API).expects('get').withArgs('//portal.test/api/v1/users/me');
+      TiAuth.initialize('//portal.test', function() {});
     }));
 
     it('unauthorizes if request to API failed', test(function() {
@@ -42,7 +42,7 @@ describe('TiAuth', () => {
       });
       var stub = spy();
       this.stub(Authentication, 'unauthorize', stub);
-      TiAuth.initialize(function() {});
+      TiAuth.initialize('//portal.test', function() {});
       assert.calledOnce(stub);
     }));
 
@@ -53,7 +53,7 @@ describe('TiAuth', () => {
       this.stub(API, 'get', function(url, success, error) {
         success(user);
       });
-      TiAuth.initialize(function() {
+      TiAuth.initialize('//portal.test', function() {
         expect(arguments[0]).to.equal('secret');
         expect(arguments[1]).to.equal(user);
       });

--- a/test/ti-auth_test.js
+++ b/test/ti-auth_test.js
@@ -18,21 +18,21 @@ describe('TiAuth', () => {
    it('attempts to authorize the user', test(function() {
      this.stub(Authentication, 'authorize', () => true);
      this.stub(API, 'get');
-     TiAuth.initialize('//portal.test', function() {});
+     TiAuth.initialize(function() {});
    }));
 
     it('unauthorizes if authorization failed', test(function() {
       this.stub(Authentication, 'authorize', false);
       var stub = spy();
       this.stub(Authentication, 'unauthorize', stub);
-      TiAuth.initialize('//portal.test', function() {});
+      TiAuth.initialize(function() {});
       assert.calledOnce(stub);
     }));
 
     it('loads user from API', test(function() {
       this.stub(Authentication, 'authorize', () => true);
-      this.mock(API).expects('get').withArgs('//portal.test/api/v1/users/me');
-      TiAuth.initialize('//portal.test', function() {});
+      this.mock(API).expects('get').withArgs('/api/v1/users/me');
+      TiAuth.initialize(function() {});
     }));
 
     it('unauthorizes if request to API failed', test(function() {
@@ -42,7 +42,7 @@ describe('TiAuth', () => {
       });
       var stub = spy();
       this.stub(Authentication, 'unauthorize', stub);
-      TiAuth.initialize('//portal.test', function() {});
+      TiAuth.initialize(function() {});
       assert.calledOnce(stub);
     }));
 
@@ -53,7 +53,7 @@ describe('TiAuth', () => {
       this.stub(API, 'get', function(url, success, error) {
         success(user);
       });
-      TiAuth.initialize('//portal.test', function() {
+      TiAuth.initialize(function() {
         expect(arguments[0]).to.equal('secret');
         expect(arguments[1]).to.equal(user);
       });


### PR DESCRIPTION
Spec: https://trello.com/c/5oOw39tU/20-use-config-file-for-endpoints

This now expects the API URL as the first parameter, so you’d use `ti-auth` as such:

```js
TiAuth.initialize('https://api.travel-intelligence.com', function(token, user) { });
```