### PR TITLE
Expose signout functionality

### DIFF
--- a/src/ti-auth.js
+++ b/src/ti-auth.js
@@ -12,5 +12,8 @@ export default {
       resolve.bind(this, token),
       Auth.unauthorize
     );
+  },
+  signout() {
+    Auth.unauthorize();
   }
 };

--- a/test/ti-auth_test.js
+++ b/test/ti-auth_test.js
@@ -59,4 +59,13 @@ describe('TiAuth', () => {
       });
     }));
   });
+
+  describe('#unauthenticate', () => {
+    it('delegates to Authentication#unauthorize', test(function() {
+      var stub = spy();
+      this.stub(Authentication, 'unauthorize', stub);
+      TiAuth.signout();
+      assert.calledOnce(stub);
+    }));
+  });
 });


### PR DESCRIPTION
Spec: https://trello.com/c/oyU0Ki1G/37-expose-signout-to-modules

So far, this has only been available to the library itself. But since there may be modules that want to provide the user with a signout feature, or unauthenticate them if a response carries a `401` response code, they now can with

```js
TiAuth.signout();
```