### PR TITLE
removed the default host from api.js

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,10 +1,8 @@
 import Authentication from './authentication';
 
-let host = 'http://portal.travel-intelligence.dev';
-
 function request(method, url, success, error) {
   let xhr = new XMLHttpRequest();
-  xhr.open(method, host + url, true);
+  xhr.open(method, url, true);
   xhr.onreadystatechange = handler;
   xhr.responseType = 'json';
   xhr.setRequestHeader('Accept', 'application/json');


### PR DESCRIPTION
We overlooked a line with the former default host in the api.js.